### PR TITLE
✨ Handle editor styles when running `fse:init`

### DIFF
--- a/resources/views/editor-style.blade.php
+++ b/resources/views/editor-style.blade.php
@@ -1,0 +1,8 @@
+/**
+ * Add the theme assets as editor styles.
+ *
+ * @return void
+ */
+add_action('after_setup_theme', function () {
+    bundle('app')->editorStyles();
+});

--- a/src/AcornFseHelperServiceProvider.php
+++ b/src/AcornFseHelperServiceProvider.php
@@ -15,6 +15,8 @@ class AcornFseHelperServiceProvider extends ServiceProvider
     public function boot()
     {
         if ($this->app->runningInConsole() && ! $this->app->isProduction()) {
+            $this->loadViewsFrom(__DIR__.'/../resources/views', 'acorn-fse-helper');
+
             $this->commands([
                 Console\Commands\FseInitCommand::class,
             ]);


### PR DESCRIPTION
- ✨ Handle adding editor styles when running `fse:init`
- 🎨 Simplify Acorn version checking
- 🧑‍💻 Simplify the `fse:init` command options
- 💄 Improve `fse:init` output styling

~~Waiting on https://github.com/roots/acorn/pull/366~~