### PR TITLE
🐛 Fix attributes on heading for block validation

### DIFF
--- a/src/Console/Commands/stubs/patterns/example-pattern.php
+++ b/src/Console/Commands/stubs/patterns/example-pattern.php
@@ -8,7 +8,7 @@
 ?>
 <!-- wp:group {"templateLock":"all","align":"full"} -->
 <div class="wp-block-group alignfull">
-  <!-- wp:heading -->
+  <!-- wp:heading {"level":3} -->
   <h3>Some heading that belongs to this block pattern.</h3>
   <!-- /wp:heading -->
 


### PR DESCRIPTION
The current pattern stub uses a `h3` tag in the heading block, but lacks the attribute `level`. Therefor we'll get a failed block validation in the editor and a notice to restore the block.